### PR TITLE
Adding google ASN

### DIFF
--- a/lists/google.list
+++ b/lists/google.list
@@ -1,3 +1,6 @@
+# Google All ASN including Gemini
+IP-ASN,15169
+
 # Google
 DOMAIN-SUFFIX,googleusercontent.com
 DOMAIN-SUFFIX,google.com


### PR DESCRIPTION
Som google services are not working with the current settings (Gemini is one of them). I've added IP-ASN,15169 to the google.list to cover all the remainings.