### PR TITLE
feat: add Constructor Group domain list

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The `lists/` directory contains specialized domain lists for different services.
 | `binance.list` | Crypto Trading | Binance exchange domains |
 | `chatgpt.list` | AI Services | ChatGPT and OpenAI domains |
 | `claude.list` | AI Services | Claude and Anthropic domains |
+| `constructor.list` | Corporate | Constructor Group domains (constr.dev, constructor.tech/.org/.dev) |
 | `google.list` | Google Services | Google search, maps, and other services |
 | `meta.list` | Social Media | Facebook, Instagram, and Meta services |
 | `rutracker.list` | File Sharing | RuTracker torrent tracker |

--- a/ebac-clash.conf.tpl
+++ b/ebac-clash.conf.tpl
@@ -46,6 +46,7 @@ rules:
   - RULE-SET,https://shadowrocket.ebac.dev/lists/claude.list,PROXY
   - RULE-SET,https://shadowrocket.ebac.dev/lists/apple-private.list,PROXY
   - RULE-SET,https://shadowrocket.ebac.dev/lists/ebac.list,PROXY
+  - RULE-SET,https://shadowrocket.ebac.dev/lists/constructor.list,PROXY
   - RULE-SET,https://shadowrocket.ebac.dev/lists/notion.list,PROXY
   - RULE-SET,https://shadowrocket.ebac.dev/lists/github.list,PROXY
   - RULE-SET,https://shadowrocket.ebac.dev/lists/cursor.list,PROXY

--- a/ebac-experimental.conf.tpl
+++ b/ebac-experimental.conf.tpl
@@ -33,6 +33,7 @@ RULE-SET,https://shadowrocket.ebac.dev/lists/chatgpt.list,PROXY
 RULE-SET,https://shadowrocket.ebac.dev/lists/claude.list,PROXY
 RULE-SET,https://shadowrocket.ebac.dev/lists/apple-private.list,PROXY
 RULE-SET,https://shadowrocket.ebac.dev/lists/ebac.list,PROXY
+RULE-SET,https://shadowrocket.ebac.dev/lists/constructor.list,PROXY
 RULE-SET,https://shadowrocket.ebac.dev/lists/notion.list,PROXY
 RULE-SET,https://shadowrocket.ebac.dev/lists/github.list,PROXY
 RULE-SET,https://shadowrocket.ebac.dev/lists/cursor.list,PROXY

--- a/ebac-gudp-reject.conf.tpl
+++ b/ebac-gudp-reject.conf.tpl
@@ -52,6 +52,7 @@ RULE-SET,https://shadowrocket.ebac.dev/lists/chatgpt.list,ru-proxy
 RULE-SET,https://shadowrocket.ebac.dev/lists/claude.list,ru-proxy
 RULE-SET,https://shadowrocket.ebac.dev/lists/apple-private.list,ru-proxy
 RULE-SET,https://shadowrocket.ebac.dev/lists/ebac.list,ru-proxy
+RULE-SET,https://shadowrocket.ebac.dev/lists/constructor.list,ru-proxy
 RULE-SET,https://shadowrocket.ebac.dev/lists/notion.list,ru-proxy
 RULE-SET,https://shadowrocket.ebac.dev/lists/github.list,ru-proxy
 RULE-SET,https://shadowrocket.ebac.dev/lists/cursor.list,ru-proxy

--- a/ebac.conf.tpl
+++ b/ebac.conf.tpl
@@ -19,6 +19,7 @@ RULE-SET,https://shadowrocket.ebac.dev/lists/ads.list,REJECT-DICT
 
 # specific ebac rules
 RULE-SET,https://shadowrocket.ebac.dev/lists/ebac.list,PROXY
+RULE-SET,https://shadowrocket.ebac.dev/lists/constructor.list,PROXY
 
 # force proxy
 RULE-SET,https://shadowrocket.ebac.dev/lists/rutracker.list,PROXY

--- a/lists/constructor.list
+++ b/lists/constructor.list
@@ -1,0 +1,6 @@
+# Constructor — домены (только второй уровень)
+DOMAIN-SUFFIX,constr.dev            # constr.dev + субдомены
+DOMAIN-SUFFIX,constructor.tech
+DOMAIN-SUFFIX,constructor.org
+DOMAIN-SUFFIX,constructor.dev
+DOMAIN-SUFFIX,dev-constructor.dev


### PR DESCRIPTION
## Что сделано

Добавлен новый доменный список `lists/constructor.list` для доменов Constructor Group и подключён рядом с `ebac.list` во всех EBAC-конфигах.

### Домены (`DOMAIN-SUFFIX`, покрывают и субдомены)
- `constr.dev` (+ субдомены)
- `constructor.tech`
- `constructor.org`
- `constructor.dev`
- `dev-constructor.dev`

### Подключение списка
| Файл | Политика |
|------|----------|
| `ebac.conf.tpl` | `PROXY` |
| `ebac-clash.conf.tpl` | `PROXY` |
| `ebac-experimental.conf.tpl` | `PROXY` |
| `ebac-gudp-reject.conf.tpl` | `ru-proxy` (как `ebac.list` в этом файле) |

Также обновлена таблица списков в `README.md`.

### Примечания
- Constructor — головная компания EBAC, поэтому список обрабатывается так же, как корпоративный `ebac.list`.
- В `clash-meta*.conf.tpl` и `contabo.conf.tpl` не добавлялось — там нет корпоративных списков (как и `ebac.list`).